### PR TITLE
trimmed user input so just pressing enter is treated as a confirmation

### DIFF
--- a/src/input/ConsoleInput.php
+++ b/src/input/ConsoleInput.php
@@ -25,7 +25,7 @@ namespace TheSeer\CLI {
         public function confirm($message) {
             $this->output->writeText(rtrim($message) . ' [Y|n] ');
             $response = fgetc(STDIN);
-            return ($response === '' || strpos('Yy', $response[0]) !== FALSE);
+            return (trim($response) === '' || strpos('Yy', $response[0]) !== FALSE);
         }
     }
 


### PR DESCRIPTION
The console output suggests that just hitting enter will confirm the message. However when doing so the response string is not empty but contains a line break, so the comparison in `ConsoleInput::confirm()` will return false. 

I trimmed the user input so the comparison returns true, as originally intended. 
